### PR TITLE
[Feat] 공통 에러 응답 클래스 작성

### DIFF
--- a/src/main/java/friends/aidelivery/common/SampleController.java
+++ b/src/main/java/friends/aidelivery/common/SampleController.java
@@ -1,7 +1,7 @@
 package friends.aidelivery.common;
 
 import friends.aidelivery.common.application.dto.CommonResponse;
-import friends.aidelivery.common.exception.CommonResultCode;
+import friends.aidelivery.common.exception.code.CommonResultCode;
 import friends.aidelivery.common.util.ResponseVOUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/friends/aidelivery/common/application/dto/CommonResponse.java
+++ b/src/main/java/friends/aidelivery/common/application/dto/CommonResponse.java
@@ -2,7 +2,6 @@ package friends.aidelivery.common.application.dto;
 
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.lang.Nullable;
 
 /**
  * 공통 응답 필드
@@ -13,8 +12,16 @@ public class CommonResponse {
 
     private int code;
     private String message;
-
-    @Nullable
     private Object results;
 
+    public CommonResponse(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public CommonResponse(int code, String message, Object results) {
+        this.code = code;
+        this.message = message;
+        this.results = results;
+    }
 }

--- a/src/main/java/friends/aidelivery/common/exception/CustomBadRequestException.java
+++ b/src/main/java/friends/aidelivery/common/exception/CustomBadRequestException.java
@@ -1,0 +1,30 @@
+package friends.aidelivery.common.exception;
+
+import friends.aidelivery.common.exception.code.CommonResultCode;
+import lombok.Getter;
+
+@Getter
+public abstract class CustomBadRequestException extends RuntimeException {
+
+    private final int code;
+
+    protected CustomBadRequestException() {
+        super(CommonResultCode.BAD_REQUEST.message());
+        this.code = CommonResultCode.BAD_REQUEST.code();
+    }
+
+    protected CustomBadRequestException(String message) {
+        super(message);
+        this.code = CommonResultCode.BAD_REQUEST.code();
+    }
+
+    protected CustomBadRequestException(int code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+    protected CustomBadRequestException(int code, String message, Throwable cause) {
+        super(message, cause);
+        this.code = code;
+    }
+}

--- a/src/main/java/friends/aidelivery/common/exception/CustomForbiddenException.java
+++ b/src/main/java/friends/aidelivery/common/exception/CustomForbiddenException.java
@@ -1,0 +1,30 @@
+package friends.aidelivery.common.exception;
+
+import friends.aidelivery.common.exception.code.CommonResultCode;
+import lombok.Getter;
+
+@Getter
+public abstract class CustomForbiddenException extends RuntimeException {
+
+    private final int code;
+
+    protected CustomForbiddenException() {
+        super(CommonResultCode.FORBIDDEN.message());
+        this.code = CommonResultCode.FORBIDDEN.code();
+    }
+
+    protected CustomForbiddenException(String message) {
+        super(message);
+        this.code = CommonResultCode.FORBIDDEN.code();
+    }
+
+    protected CustomForbiddenException(int code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+    protected CustomForbiddenException(int code, String message, Throwable cause) {
+        super(message, cause);
+        this.code = code;
+    }
+}

--- a/src/main/java/friends/aidelivery/common/exception/CustomNotFoundException.java
+++ b/src/main/java/friends/aidelivery/common/exception/CustomNotFoundException.java
@@ -1,0 +1,30 @@
+package friends.aidelivery.common.exception;
+
+import friends.aidelivery.common.exception.code.CommonResultCode;
+import lombok.Getter;
+
+@Getter
+public abstract class CustomNotFoundException extends RuntimeException {
+
+    private final int code;
+
+    protected CustomNotFoundException() {
+        super(CommonResultCode.DATA_NOT_FOUNT.message());
+        this.code = CommonResultCode.DATA_NOT_FOUNT.code();
+    }
+
+    protected CustomNotFoundException(String message) {
+        super(message);
+        this.code = CommonResultCode.DATA_NOT_FOUNT.code();
+    }
+
+    protected CustomNotFoundException(int code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+    protected CustomNotFoundException(int code, String message, Throwable cause) {
+        super(message, cause);
+        this.code = code;
+    }
+}

--- a/src/main/java/friends/aidelivery/common/exception/CustomUnauthorizedException.java
+++ b/src/main/java/friends/aidelivery/common/exception/CustomUnauthorizedException.java
@@ -1,0 +1,30 @@
+package friends.aidelivery.common.exception;
+
+import friends.aidelivery.common.exception.code.CommonResultCode;
+import lombok.Getter;
+
+@Getter
+public abstract class CustomUnauthorizedException extends RuntimeException {
+
+    private final int code;
+
+    protected CustomUnauthorizedException() {
+        super(CommonResultCode.UNAUTHORIZED.message());
+        this.code = CommonResultCode.UNAUTHORIZED.code();
+    }
+
+    protected CustomUnauthorizedException(String message) {
+        super(message);
+        this.code = CommonResultCode.UNAUTHORIZED.code();
+    }
+
+    protected CustomUnauthorizedException(int code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+    protected CustomUnauthorizedException(int code, String message, Throwable cause) {
+        super(message, cause);
+        this.code = code;
+    }
+}

--- a/src/main/java/friends/aidelivery/common/exception/code/CommonResultCode.java
+++ b/src/main/java/friends/aidelivery/common/exception/code/CommonResultCode.java
@@ -1,20 +1,17 @@
-package friends.aidelivery.common.exception;
+package friends.aidelivery.common.exception.code;
 
 public enum CommonResultCode {
 
-    /**
-     * 성공 처리
-     */
     SUCCESS(200, "요청 성공"),
 
-    /**
-     * 로그인이 안 되어 있어 권한이 없는 경우
-     */
-    UNAUTHORIZED(401, "권한이 없습니다."),
+    BAD_REQUEST(400, "잘못된 요청입니다."),
 
-    /**
-     * 서버 에러
-     */
+    UNAUTHORIZED(401, "유효한 인증 정보가 아닙니다."),
+
+    FORBIDDEN(403, "권한이 없습니다."),
+
+    DATA_NOT_FOUNT(404, "데이터를 찾을 수 없습니다."),
+
     ERROR(500, "서버 에러");
 
     /**

--- a/src/main/java/friends/aidelivery/common/presentation/GlobalExceptionHandler.java
+++ b/src/main/java/friends/aidelivery/common/presentation/GlobalExceptionHandler.java
@@ -1,0 +1,63 @@
+package friends.aidelivery.common.presentation;
+
+import friends.aidelivery.common.application.dto.CommonResponse;
+import friends.aidelivery.common.exception.CustomBadRequestException;
+import friends.aidelivery.common.exception.CustomForbiddenException;
+import friends.aidelivery.common.exception.CustomNotFoundException;
+import friends.aidelivery.common.exception.CustomUnauthorizedException;
+import friends.aidelivery.common.exception.code.CommonResultCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j(topic = "GLOBAL_EXCEPTION_HANDLER")
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(value = {CustomBadRequestException.class})
+    public ResponseEntity<CommonResponse> customBadRequestException(
+        final CustomBadRequestException ex) {
+        log.error("CustomBadRequestException: ", ex);
+
+        return ResponseEntity.badRequest()
+            .body(new CommonResponse(ex.getCode(), ex.getMessage()));
+    }
+
+    @ExceptionHandler(value = {CustomNotFoundException.class})
+    public ResponseEntity<CommonResponse> customNotFoundException(
+        final CustomNotFoundException ex) {
+        log.error("CustomNotFoundException: ", ex);
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(new CommonResponse(ex.getCode(), ex.getMessage()));
+    }
+
+    @ExceptionHandler(value = {CustomForbiddenException.class})
+    public ResponseEntity<CommonResponse> customForbiddenException(
+        final CustomForbiddenException ex) {
+        log.error("CustomForbiddenException: ", ex);
+
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+            .body(new CommonResponse(ex.getCode(), ex.getMessage()));
+    }
+
+    @ExceptionHandler(value = {CustomUnauthorizedException.class})
+    public ResponseEntity<CommonResponse> customUnauthorizedException(
+        final CustomUnauthorizedException ex) {
+        log.error("CustomUnauthorizedException: ", ex);
+
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+            .body(new CommonResponse(ex.getCode(), ex.getMessage()));
+    }
+
+    @ExceptionHandler(value = {RuntimeException.class})
+    public ResponseEntity<CommonResponse> runtimeException(final RuntimeException ex) {
+        log.error("RuntimeException: ", ex);
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(new CommonResponse(CommonResultCode.ERROR.code(),
+                CommonResultCode.ERROR.message()));
+    }
+}

--- a/src/main/java/friends/aidelivery/common/util/ResponseVOUtils.java
+++ b/src/main/java/friends/aidelivery/common/util/ResponseVOUtils.java
@@ -1,7 +1,7 @@
 package friends.aidelivery.common.util;
 
 import friends.aidelivery.common.application.dto.CommonResponse;
-import friends.aidelivery.common.exception.CommonResultCode;
+import friends.aidelivery.common.exception.code.CommonResultCode;
 import lombok.Builder;
 import lombok.experimental.UtilityClass;
 
@@ -12,63 +12,63 @@ import lombok.experimental.UtilityClass;
 @Builder
 public class ResponseVOUtils {
 
-  /**
-   * 응답 성공 시 반환 메서드 반환 결과가 존재할 때
-   *
-   * @param results Object
-   * @return CommonResponse
-   */
-  public static CommonResponse getSuccessResponse(Object results) {
+    /**
+     * 응답 성공 시 반환 메서드 반환 결과가 존재할 때
+     *
+     * @param results Object
+     * @return CommonResponse
+     */
+    public static CommonResponse getSuccessResponse(Object results) {
 
-    CommonResultCode resultCode = CommonResultCode.SUCCESS;
+        CommonResultCode resultCode = CommonResultCode.SUCCESS;
 
-    return CommonResponse.builder()
-        .code(resultCode.code())
-        .message(resultCode.message())
-        .results(results)
-        .build();
-  }
+        return CommonResponse.builder()
+            .code(resultCode.code())
+            .message(resultCode.message())
+            .results(results)
+            .build();
+    }
 
-  /**
-   * 응답 성공 시 반환 메서드 반환 결과가 존재하지 않을 때
-   *
-   * @return CommonResponse
-   */
-  public static CommonResponse getSuccessResponse() {
+    /**
+     * 응답 성공 시 반환 메서드 반환 결과가 존재하지 않을 때
+     *
+     * @return CommonResponse
+     */
+    public static CommonResponse getSuccessResponse() {
 
-    CommonResultCode resultCode = CommonResultCode.SUCCESS;
+        CommonResultCode resultCode = CommonResultCode.SUCCESS;
 
-    return CommonResponse.builder()
-        .code(resultCode.code())
-        .message(resultCode.message())
-        .build();
-  }
+        return CommonResponse.builder()
+            .code(resultCode.code())
+            .message(resultCode.message())
+            .build();
+    }
 
-  /**
-   * 응답 실패 시 메서드 코드 존재
-   *
-   * @param resultCode CommonResultCode
-   * @return CommonResponse
-   */
-  public static CommonResponse getFailResponse(CommonResultCode resultCode) {
-    return CommonResponse.builder()
-        .code(resultCode.code())
-        .message(resultCode.message())
-        .build();
-  }
+    /**
+     * 응답 실패 시 메서드 코드 존재
+     *
+     * @param resultCode CommonResultCode
+     * @return CommonResponse
+     */
+    public static CommonResponse getFailResponse(CommonResultCode resultCode) {
+        return CommonResponse.builder()
+            .code(resultCode.code())
+            .message(resultCode.message())
+            .build();
+    }
 
-  /**
-   * 응답 실패 시 커스텀 메시지 반환
-   *
-   * @param code    String
-   * @param message String
-   * @return CommonResponse
-   */
-  public static CommonResponse getFailResponse(int code, String message) {
-    return CommonResponse.builder()
-        .code(code)
-        .message(message)
-        .build();
-  }
+    /**
+     * 응답 실패 시 커스텀 메시지 반환
+     *
+     * @param code    String
+     * @param message String
+     * @return CommonResponse
+     */
+    public static CommonResponse getFailResponse(int code, String message) {
+        return CommonResponse.builder()
+            .code(code)
+            .message(message)
+            .build();
+    }
 
 }


### PR DESCRIPTION
## 📄 설명

> 공통적으로 쓰일 에러 응답 클래스 작성했습니다.

[예시] BadRequset로 예시를 들면, 먼저 상속 받을 클래스를 만든 후 해당 클래스를 상속합니다.

[ex] public class UserBadRequestException extends CustomBadRequestException

해당 클래스에서 새로운 응답 코드와 메시지를 내려 주고 싶을 경우 해당 생성자를 생성합니다.
- [상황] 휴대폰 번호가 유효하지 않을 때, 450 코드와 "휴대폰 번호가 유효하지 않습니다." 파라미터 전달
    public MemberException(int code, String message) {
        super(code, message);
    }

해당 클래스에서 메시지만 내려 주고 싶을 경우 해당 생성자를 생성합니다.
- [상황] 이름이 100자가 넘었을 때, 400 코드와 "이름을 다시 확인해주세요." 파라미터 전달
    public MemberException(String message) {
        super(message);
    }

메시지만 내려 주는 경우에는 정의된 공통 에러 코드(400)가 내려갑니다. (CustomBadRequestException 클래스 참조)
메시지와 응답 메시지 없이 오류 코드를 내려 주는 경우에도 정의된 공통 에러 코드(BAD_REQUEST(400, "잘못된 요청입니다."))가 내려갑니다.

if (value != 0) {
 throw new MemberException.EmailRegexException(value);
}

에러 던질 곳에서 위 방법 등으로 사용하시면 됩니다.

## 📌 관련 이슈

> #16 

## ⚠️ 주의사항

> 이해가 되지 않는 부분이 있다면 언제든지 질문해 주세요!
수정해야 할 부분도 괜찮습니다!
