### PR TITLE
[Feat] Gemini Entity 생성 및 Api 요청 로직 구현

### DIFF
--- a/src/main/java/friends/aidelivery/AiDeliveryApplication.java
+++ b/src/main/java/friends/aidelivery/AiDeliveryApplication.java
@@ -2,7 +2,9 @@ package friends.aidelivery;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class AiDeliveryApplication {
 

--- a/src/main/java/friends/aidelivery/gemini/application/GeminiService.java
+++ b/src/main/java/friends/aidelivery/gemini/application/GeminiService.java
@@ -1,0 +1,44 @@
+package friends.aidelivery.gemini.application;
+
+import friends.aidelivery.gemini.application.dto.request.GeminiCreateRequest;
+import friends.aidelivery.gemini.application.dto.request.GeminiFeignRequest;
+import friends.aidelivery.gemini.application.dto.response.GeminiFeignResponse;
+import friends.aidelivery.gemini.application.dto.response.GeminiResponse;
+import friends.aidelivery.gemini.domain.Gemini;
+import friends.aidelivery.gemini.domain.repository.GeminiRepository;
+import friends.aidelivery.gemini.domain.vo.GeminiRequest;
+import friends.aidelivery.gemini.infrastructure.client.GeminiFeignClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GeminiService {
+
+    private final GeminiFeignClient geminiFeignClient;
+    private final GeminiRepository geminiRepository;
+
+    @Value("${google.api.key}")
+    private String key;
+
+    @Transactional
+    public GeminiResponse create(final GeminiCreateRequest request) {
+        final GeminiRequest geminiRequest = new GeminiRequest(request.content());
+
+        final String response = generateContent(geminiRequest);
+
+        final Gemini gemini = new Gemini(request.requestType(), geminiRequest, response);
+        final Gemini saved = geminiRepository.save(gemini);
+        return GeminiResponse.of(saved);
+    }
+
+    private String generateContent(GeminiRequest geminiRequest) {
+        final GeminiFeignRequest feignRequest = GeminiFeignRequest.of(geminiRequest.getValue());
+        final GeminiFeignResponse response = geminiFeignClient.generateContent(
+            key, feignRequest);
+        return response.getFirstText();
+    }
+}

--- a/src/main/java/friends/aidelivery/gemini/application/dto/request/GeminiCreateRequest.java
+++ b/src/main/java/friends/aidelivery/gemini/application/dto/request/GeminiCreateRequest.java
@@ -1,0 +1,11 @@
+package friends.aidelivery.gemini.application.dto.request;
+
+import friends.aidelivery.gemini.domain.RequestType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record GeminiCreateRequest(
+    @NotBlank(message = "요청 내용은 필수입니다.") String content,
+    @NotNull(message = "요청 유형은 필수입니다.") RequestType requestType) {
+
+}

--- a/src/main/java/friends/aidelivery/gemini/application/dto/request/GeminiFeignRequest.java
+++ b/src/main/java/friends/aidelivery/gemini/application/dto/request/GeminiFeignRequest.java
@@ -1,0 +1,20 @@
+package friends.aidelivery.gemini.application.dto.request;
+
+import java.util.List;
+
+public record GeminiFeignRequest(List<Content> contents) {
+
+    public static GeminiFeignRequest of(final String text) {
+        final Part part = new Part(text);
+        final Content content = new Content(List.of(part));
+        return new GeminiFeignRequest(List.of(content));
+    }
+
+    public record Content(List<Part> parts) {
+
+    }
+
+    public record Part(String text) {
+
+    }
+}

--- a/src/main/java/friends/aidelivery/gemini/application/dto/response/GeminiFeignResponse.java
+++ b/src/main/java/friends/aidelivery/gemini/application/dto/response/GeminiFeignResponse.java
@@ -1,0 +1,22 @@
+package friends.aidelivery.gemini.application.dto.response;
+
+import java.util.List;
+
+public record GeminiFeignResponse(List<Candidate> candidates) {
+
+    public String getFirstText() {
+        return candidates().get(0).content().parts().get(0).text();
+    }
+
+    public record Candidate(Content content) {
+
+    }
+
+    public record Content(List<Part> parts) {
+
+    }
+
+    public record Part(String text) {
+
+    }
+}

--- a/src/main/java/friends/aidelivery/gemini/application/dto/response/GeminiResponse.java
+++ b/src/main/java/friends/aidelivery/gemini/application/dto/response/GeminiResponse.java
@@ -1,0 +1,12 @@
+package friends.aidelivery.gemini.application.dto.response;
+
+import friends.aidelivery.gemini.domain.Gemini;
+import friends.aidelivery.gemini.domain.RequestType;
+
+public record GeminiResponse(RequestType type, String requestText, String responseText) {
+
+    public static GeminiResponse of(final Gemini gemini) {
+        return new GeminiResponse(gemini.getType(), gemini.getRequest().getValue(),
+            gemini.getResponse());
+    }
+}

--- a/src/main/java/friends/aidelivery/gemini/domain/Gemini.java
+++ b/src/main/java/friends/aidelivery/gemini/domain/Gemini.java
@@ -1,0 +1,43 @@
+package friends.aidelivery.gemini.domain;
+
+import friends.aidelivery.gemini.domain.vo.GeminiRequest;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "p_gemini")
+@Entity
+public class Gemini {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "gemini_id")
+    private UUID id;
+
+    @Enumerated(EnumType.STRING)
+    private RequestType type;
+
+    @Embedded
+    private GeminiRequest request;
+
+    @Column(name = "response", nullable = false)
+    private String response;
+
+    public Gemini(final RequestType type, final GeminiRequest request, final String response) {
+        this.type = type;
+        this.request = request;
+        this.response = response;
+    }
+}

--- a/src/main/java/friends/aidelivery/gemini/domain/RequestType.java
+++ b/src/main/java/friends/aidelivery/gemini/domain/RequestType.java
@@ -1,0 +1,5 @@
+package friends.aidelivery.gemini.domain;
+
+public enum RequestType {
+    PRODUCT_CONTENT;
+}

--- a/src/main/java/friends/aidelivery/gemini/domain/repository/GeminiRepository.java
+++ b/src/main/java/friends/aidelivery/gemini/domain/repository/GeminiRepository.java
@@ -1,0 +1,8 @@
+package friends.aidelivery.gemini.domain.repository;
+
+import friends.aidelivery.gemini.domain.Gemini;
+
+public interface GeminiRepository {
+
+    Gemini save(Gemini gemini);
+}

--- a/src/main/java/friends/aidelivery/gemini/domain/vo/GeminiRequest.java
+++ b/src/main/java/friends/aidelivery/gemini/domain/vo/GeminiRequest.java
@@ -1,0 +1,44 @@
+package friends.aidelivery.gemini.domain.vo;
+
+import friends.aidelivery.gemini.exception.GeminiRequestBlankException;
+import friends.aidelivery.gemini.exception.GeminiRequestLengthException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class GeminiRequest {
+
+    public static final int MAX_LENGTH = 200;
+    public static final String APPENDED_TEXT = "답변을 최대한 간결하게 50자 이하로";
+
+    @Column(name = "request", nullable = false)
+    private String value;
+
+    public GeminiRequest(final String value) {
+        validate(value);
+        this.value = appendInstruction(value);
+    }
+
+    private void validate(final String value) {
+        if (value == null) {
+            throw new NullPointerException("요청 내용은 null일 수 없습니다.");
+        }
+        if (value.isBlank()) {
+            throw new GeminiRequestBlankException();
+        }
+        if (value.length() > MAX_LENGTH) {
+            throw new GeminiRequestLengthException(MAX_LENGTH, value);
+        }
+    }
+
+    private String appendInstruction(final String value) {
+        return value + " " + APPENDED_TEXT;
+    }
+}

--- a/src/main/java/friends/aidelivery/gemini/exception/GeminiRequestBlankException.java
+++ b/src/main/java/friends/aidelivery/gemini/exception/GeminiRequestBlankException.java
@@ -1,0 +1,10 @@
+package friends.aidelivery.gemini.exception;
+
+import friends.aidelivery.common.exception.CustomBadRequestException;
+
+public class GeminiRequestBlankException extends CustomBadRequestException {
+
+    public GeminiRequestBlankException() {
+        super("요청 내용은 공백을 제외한 1자 이상이어야 합니다.");
+    }
+}

--- a/src/main/java/friends/aidelivery/gemini/exception/GeminiRequestLengthException.java
+++ b/src/main/java/friends/aidelivery/gemini/exception/GeminiRequestLengthException.java
@@ -1,0 +1,15 @@
+package friends.aidelivery.gemini.exception;
+
+import friends.aidelivery.common.exception.CustomBadRequestException;
+
+public class GeminiRequestLengthException extends CustomBadRequestException {
+
+    public GeminiRequestLengthException(final int allowed, final String input) {
+        super(
+            String.format(
+                "요청 내용의 길이가 최대 길이를 초과했습니다. - 요청 정보 { 허용 값 : %d, 입력 값 : %d }",
+                allowed,
+                input.length())
+        );
+    }
+}

--- a/src/main/java/friends/aidelivery/gemini/infrastructure/client/GeminiFeignClient.java
+++ b/src/main/java/friends/aidelivery/gemini/infrastructure/client/GeminiFeignClient.java
@@ -1,0 +1,18 @@
+package friends.aidelivery.gemini.infrastructure.client;
+
+import friends.aidelivery.gemini.application.dto.request.GeminiFeignRequest;
+import friends.aidelivery.gemini.application.dto.response.GeminiFeignResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "geminiClient", url = "https://generativelanguage.googleapis.com/v1beta/models")
+public interface GeminiFeignClient {
+
+    @PostMapping("/gemini-1.5-flash:generateContent")
+    GeminiFeignResponse generateContent(
+        @RequestParam("key") String key,
+        @RequestBody GeminiFeignRequest request
+    );
+}

--- a/src/main/java/friends/aidelivery/gemini/infrastructure/jpa/GeminiJpaRepository.java
+++ b/src/main/java/friends/aidelivery/gemini/infrastructure/jpa/GeminiJpaRepository.java
@@ -1,0 +1,9 @@
+package friends.aidelivery.gemini.infrastructure.jpa;
+
+import friends.aidelivery.gemini.domain.Gemini;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GeminiJpaRepository extends JpaRepository<Gemini, UUID> {
+
+}

--- a/src/main/java/friends/aidelivery/gemini/infrastructure/repository/GeminiRepositoryImpl.java
+++ b/src/main/java/friends/aidelivery/gemini/infrastructure/repository/GeminiRepositoryImpl.java
@@ -1,0 +1,19 @@
+package friends.aidelivery.gemini.infrastructure.repository;
+
+import friends.aidelivery.gemini.domain.Gemini;
+import friends.aidelivery.gemini.domain.repository.GeminiRepository;
+import friends.aidelivery.gemini.infrastructure.jpa.GeminiJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class GeminiRepositoryImpl implements GeminiRepository {
+
+    private final GeminiJpaRepository geminiJpaRepository;
+
+    @Override
+    public Gemini save(Gemini gemini) {
+        return geminiJpaRepository.save(gemini);
+    }
+}

--- a/src/main/java/friends/aidelivery/gemini/presentation/GeminiController.java
+++ b/src/main/java/friends/aidelivery/gemini/presentation/GeminiController.java
@@ -1,0 +1,30 @@
+package friends.aidelivery.gemini.presentation;
+
+import friends.aidelivery.common.application.dto.CommonResponse;
+import friends.aidelivery.common.util.ResponseVOUtils;
+import friends.aidelivery.gemini.application.GeminiService;
+import friends.aidelivery.gemini.application.dto.request.GeminiCreateRequest;
+import friends.aidelivery.gemini.application.dto.response.GeminiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/gemini")
+public class GeminiController {
+
+    private final GeminiService geminiService;
+
+    @PostMapping("")
+    public ResponseEntity<CommonResponse> create(@Valid @RequestBody GeminiCreateRequest request) {
+        GeminiResponse response = geminiService.create(request);
+        return new ResponseEntity<>(ResponseVOUtils.getSuccessResponse(response),
+            HttpStatus.CREATED);
+    }
+}


### PR DESCRIPTION
## 📄 설명

- Gemini Entity 생성
- `@EnableFeignClient` 활성화
- Gemini Api를 사용한 generateContent 구현

### 요청 및 응답 예시
<img width="909" alt="스크린샷 2025-02-17 오전 11 56 53" src="https://github.com/user-attachments/assets/eaf6cf78-c079-46eb-bcce-083db248bfec" />

## 📌 관련 이슈

#21 

## ⚠️ 주의사항

- 현재 Api key는 applicatiion-local.yml 에 있고 추후 설정파일과 gitignore 올릴게요
- Postman으로 테스트 성공 후 올리는 거라 문제 없습니다!
