### PR TITLE
[Feat] jwtauthorizationfilter 수정

### DIFF
--- a/src/main/java/friends/aidelivery/common/configuration/SecurityConfig.java
+++ b/src/main/java/friends/aidelivery/common/configuration/SecurityConfig.java
@@ -59,11 +59,12 @@ public class SecurityConfig {
         );
 
         http.authorizeHttpRequests(authorizeHttpRequests ->
-                authorizeHttpRequests
-                        //.requestMatchers("/**").permitAll() //개발 임시 인증 토큰 허용
-                        .requestMatchers("/admins/**").hasAuthority("MASTER") // hasAuthority대신 hasRole을 쓰면 PREFIX로 ROLE_이 붙어버려서 계속 오류났음
-                        .requestMatchers("/users/login", "/users/signIn").permitAll()
-                        .anyRequest().authenticated()
+            authorizeHttpRequests
+                //.requestMatchers("/**").permitAll() //개발 임시 인증 토큰 허용
+                .requestMatchers("/admins/**").hasAnyAuthority("MASTER",
+                    "MANAGER") // hasAuthority대신 hasRole을 쓰면 PREFIX로 ROLE_이 붙어버려서 계속 오류났음
+                .requestMatchers("/users/login", "/users/signIn").permitAll()
+                .anyRequest().authenticated()
         );
 
         http.addFilterBefore(jwtAuthorizationFilter(), JwtAuthenticationFilter.class);

--- a/src/main/java/friends/aidelivery/common/infrastructure/security/JwtTokenProvider.java
+++ b/src/main/java/friends/aidelivery/common/infrastructure/security/JwtTokenProvider.java
@@ -11,8 +11,8 @@ import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
@@ -40,12 +40,13 @@ public class JwtTokenProvider {
     }
 
     // 토큰 생성
-    public String createToken(String email, UserRoleEnum role) {
+    public String createToken(String email, UserRoleEnum role, Long userId) {
         Date date = new Date();
         long expirationTime = 86400L * 1000;  // 1일을 밀리초 단위로 변경
 
         return Jwts.builder()
             .setSubject(email)
+            .claim("userId", userId)
             .claim(AUTHORIZATION_KEY, role.getAuthority())
             .setExpiration(new Date(date.getTime() + expirationTime))
             .setIssuedAt(date)
@@ -56,6 +57,7 @@ public class JwtTokenProvider {
     // header 에서 JWT 가져오기
     public String getJwtFromHeader(HttpServletRequest request) {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
             return bearerToken.substring(7);
         }
@@ -80,16 +82,13 @@ public class JwtTokenProvider {
 
     // JWT Cookie 에 저장
     public void addJwtToCookie(String token, HttpServletResponse res) {
-        try {
-            token = URLEncoder.encode(token, "utf-8").replaceAll("\\+", "%20"); // Cookie Value 에는 공백이 불가능해서 encoding 진행
-            //token = BEARER_PREFIX+token;
-            Cookie cookie = new Cookie(AUTHORIZATION_HEADER, token); // Name-Value
-            cookie.setPath("/");
+        token = URLEncoder.encode(BEARER_PREFIX + token, StandardCharsets.UTF_8)
+            .replace("+", "%20");
 
-            // Response 객체에 Cookie 추가
-            res.addCookie(cookie);
-        } catch (UnsupportedEncodingException e) {
-            log.error(e.getMessage());
-        }
+        Cookie cookie = new Cookie(AUTHORIZATION_HEADER, token); // Name-Value
+        cookie.setPath("/");
+
+        // Response 객체에 Cookie 추가
+        res.addCookie(cookie);
     }
 }

--- a/src/main/java/friends/aidelivery/common/infrastructure/security/UserDetailsImpl.java
+++ b/src/main/java/friends/aidelivery/common/infrastructure/security/UserDetailsImpl.java
@@ -1,43 +1,49 @@
 package friends.aidelivery.common.infrastructure.security;
 
-import friends.aidelivery.user.domain.User;
 import friends.aidelivery.user.domain.enums.UserRoleEnum;
-import java.util.ArrayList;
+import friends.aidelivery.user.domain.vo.Email;
 import java.util.Collection;
 import java.util.List;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.userdetails.UserDetails;
 
 @Slf4j(topic = "UserDetailsImpl")
 @Getter
 public class UserDetailsImpl implements UserDetails {
 
-    private final User user;
+    private final String email;
+    private final Long userId;
+    private final UserRoleEnum role;  // Role 정보도 저장
+    private final String password;
+    private final List<GrantedAuthority> authorities;
 
-    public UserDetailsImpl(User user) {
-        this.user = user;// 권한 부여
+    public Email getEmail() {
+        return new Email(email);
     }
 
+    public UserDetailsImpl(String email, Long userId, UserRoleEnum role, String password) {
+        this.email = email;
+        this.userId = userId;
+        this.role = role;
+        this.password = password;
+        this.authorities = AuthorityUtils.createAuthorityList(role.name());
+    }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        UserRoleEnum role = user.getRole();
-        List<SimpleGrantedAuthority> authorities = new ArrayList<>();
-        authorities.add(
-            new SimpleGrantedAuthority(role.getAuthority()));  // role.getAuthority()로 권한 추가
         return authorities;
     }
 
     @Override
     public String getPassword() {
-        return user.getPassword();
+        return password;
     }
 
     @Override
     public String getUsername() {
-        return user.getEmail().getValue();
+        return email;
     }
 }

--- a/src/main/java/friends/aidelivery/common/infrastructure/security/UserDetailsServiceImpl.java
+++ b/src/main/java/friends/aidelivery/common/infrastructure/security/UserDetailsServiceImpl.java
@@ -26,10 +26,12 @@ public class UserDetailsServiceImpl implements UserDetailsService {
         User user = userRepository.findByEmail(email)
             .orElseThrow(() -> {
                 log.error("이메일 '{}'에 해당하는 유저를 찾을 수 없음!", email.getValue());
-                return new UsernameNotFoundException("이메일 " + email.getValue() + "에 해당하는 유저를 찾을 수 없습니다.");
+                return new UsernameNotFoundException(
+                    "이메일 " + email.getValue() + "에 해당하는 유저를 찾을 수 없습니다.");
             });
 
         log.info("로그인:{}", user);
-        return new UserDetailsImpl(user);
+        return new UserDetailsImpl(user.getEmail().getValue(), user.getId(), user.getRole(),
+            user.getPassword());
     }
 }

--- a/src/main/java/friends/aidelivery/common/infrastructure/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/friends/aidelivery/common/infrastructure/security/filter/JwtAuthenticationFilter.java
@@ -1,9 +1,9 @@
 package friends.aidelivery.common.infrastructure.security.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import friends.aidelivery.common.exception.JwtTokenException;
 import friends.aidelivery.common.infrastructure.security.JwtTokenProvider;
 import friends.aidelivery.common.infrastructure.security.UserDetailsImpl;
-import friends.aidelivery.common.exception.JwtTokenException;
 import friends.aidelivery.user.application.dto.request.UserLoginRequestDto;
 import friends.aidelivery.user.domain.enums.UserRoleEnum;
 import jakarta.servlet.FilterChain;
@@ -34,8 +34,8 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         HttpServletResponse response)
         throws AuthenticationException {
         try {
-
-            UserLoginRequestDto loginRequest = new ObjectMapper().readValue(request.getInputStream(),
+            UserLoginRequestDto loginRequest = new ObjectMapper().readValue(
+                request.getInputStream(),
                 UserLoginRequestDto.class);
 
             log.info(loginRequest.toString());
@@ -59,16 +59,18 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         throws IOException, ServletException {
         log.info("로그인 성공");
         String userEmail = ((UserDetailsImpl) authResult.getPrincipal()).getUsername();
-        UserRoleEnum role = ((UserDetailsImpl) authResult.getPrincipal()).getUser()
-            .getRole();
+        UserRoleEnum role = ((UserDetailsImpl) authResult.getPrincipal()).getRole();
+        Long userId = ((UserDetailsImpl) authResult.getPrincipal()).getUserId();
 
-        String token = jwtTokenProvider.createToken(userEmail, role);
-        jwtTokenProvider.addJwtToCookie(token,response);
+        String token = jwtTokenProvider.createToken(userEmail, role, userId);
+        jwtTokenProvider.addJwtToCookie(token, response);
 
     }
 
     @Override
-    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException, ServletException {
+    protected void unsuccessfulAuthentication(HttpServletRequest request,
+        HttpServletResponse response, AuthenticationException failed)
+        throws IOException, ServletException {
         log.info("로그인 실패");
         response.setStatus(401);
     }

--- a/src/main/java/friends/aidelivery/common/infrastructure/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/friends/aidelivery/common/infrastructure/security/filter/JwtAuthorizationFilter.java
@@ -1,24 +1,25 @@
 package friends.aidelivery.common.infrastructure.security.filter;
 
 
+import static friends.aidelivery.common.infrastructure.security.JwtTokenProvider.AUTHORIZATION_KEY;
+
 import friends.aidelivery.common.infrastructure.security.JwtTokenProvider;
+import friends.aidelivery.common.infrastructure.security.UserDetailsImpl;
+import friends.aidelivery.user.domain.enums.UserRoleEnum;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
-import java.util.List;
 
 @Slf4j
 @Component
@@ -34,16 +35,20 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         throws ServletException, IOException {
 
         String token = jwtTokenProvider.getJwtFromHeader(request);
+        log.info(token);
 
         if (token != null && jwtTokenProvider.validateToken(token)) {
             Claims claims = jwtTokenProvider.getUserInfoFromToken(token);
             String email = claims.getSubject();
+            Long userId = claims.get("userId", Long.class);
+            String roleString = claims.get(AUTHORIZATION_KEY, String.class);
+            UserRoleEnum role = UserRoleEnum.valueOf(roleString);
 
-            UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+            UserDetails userDetails = new UserDetailsImpl(email, userId, role, null);
 
             UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(userDetails, null,
-                            userDetails.getAuthorities());
+                new UsernamePasswordAuthenticationToken(userDetails, null,
+                    userDetails.getAuthorities());
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 

--- a/src/main/java/friends/aidelivery/order/presentation/OrderController.java
+++ b/src/main/java/friends/aidelivery/order/presentation/OrderController.java
@@ -39,7 +39,7 @@ public class OrderController {
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @Valid @RequestBody OrderCreateRequest request) {
         OrderResponse response = orderService.createOrder(request,
-            userDetails.getUser().getEmail());
+            userDetails.getEmail());
         return new ResponseEntity<>(ResponseVOUtils.getSuccessResponse(response),
             HttpStatus.CREATED);
     }
@@ -49,7 +49,7 @@ public class OrderController {
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @PathVariable UUID orderId,
         @RequestBody OrderCancelRequest request) {
-        orderService.cancelOrder(orderId, userDetails.getUser().getEmail(), request);
+        orderService.cancelOrder(orderId, userDetails.getEmail(), request);
         return new ResponseEntity<>(ResponseVOUtils.getSuccessResponse(), HttpStatus.OK);
     }
 
@@ -57,7 +57,7 @@ public class OrderController {
     public ResponseEntity<CommonResponse> acceptOrder(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @PathVariable UUID orderId) {
-        orderService.acceptOrder(orderId, userDetails.getUser().getEmail());
+        orderService.acceptOrder(orderId, userDetails.getEmail());
         return new ResponseEntity<>(ResponseVOUtils.getSuccessResponse(), HttpStatus.OK);
     }
 
@@ -65,7 +65,7 @@ public class OrderController {
     public ResponseEntity<CommonResponse> rejectOrder(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @PathVariable UUID orderId) {
-        orderService.rejectOrder(orderId, userDetails.getUser().getEmail());
+        orderService.rejectOrder(orderId, userDetails.getEmail());
         return new ResponseEntity<>(ResponseVOUtils.getSuccessResponse(), HttpStatus.OK);
     }
 }

--- a/src/main/java/friends/aidelivery/user/application/UserService.java
+++ b/src/main/java/friends/aidelivery/user/application/UserService.java
@@ -7,13 +7,9 @@ import friends.aidelivery.user.application.dto.request.UserLoginRequestDto;
 import friends.aidelivery.user.application.dto.response.UserInfoResponseDto;
 import friends.aidelivery.user.application.dto.response.UserResponseDto;
 import friends.aidelivery.user.domain.User;
-import friends.aidelivery.user.domain.enums.UserRoleEnum;
+import friends.aidelivery.user.domain.repository.UserRepository;
 import friends.aidelivery.user.exception.UserMismatchException;
 import friends.aidelivery.user.exception.UserNotFoundException;
-import friends.aidelivery.user.domain.repository.UserRepository;
-import friends.aidelivery.user.domain.vo.Email;
-import friends.aidelivery.user.exception.UserPasswordMismatchException;
-import friends.aidelivery.user.exception.UserUnauthorizedException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -40,26 +36,11 @@ public class UserService {
         return UserInfoResponseDto.of(saved);
     }
 
-    public UserResponseDto login(UserLoginRequestDto userLoginRequest) {
-
-        Email email = new Email(userLoginRequest.getEmail());
-        String encodedPassword = passwordEncoder.encode(userLoginRequest.getPassword());
-
-        User user = userRepository.findByEmail(email)
-            .orElseThrow(UserNotFoundException::new);
-
-        if (!encodedPassword.equals(user.getPassword())) {
-            throw new UserPasswordMismatchException();
-        }
-
-        return UserResponseDto.of(user);
-    }
-
     public UserResponseDto findUserInfo(Long userId, UserDetailsImpl userDetails) {
 
         User user = getUserOrElseThrow(userId);
 
-        if (!userDetails.getUser().getId().equals(user.getId())) {
+        if (!userDetails.getUserId().equals(user.getId())) {
             throw new UserMismatchException();
         }
 
@@ -72,7 +53,7 @@ public class UserService {
 
         User user = getUserOrElseThrow(userId);
 
-        if (!userDetails.getUser().getId().equals(userId)) {
+        if (!userDetails.getUserId().equals(userId)) {
             throw new UserMismatchException();
         }
         user.updateUser(userInfoRequestDto);
@@ -88,14 +69,16 @@ public class UserService {
         /**
          * 프론트에서 토큰을 지워주는거라 딱히 여기서는 뭐 안함
          */
-        return UserResponseDto.of(userDetails.getUser());
+        //return UserResponseDto.of(userDetails.getUser());
+        return null;
     }
 
     public Page<AdminUserRequestDto> findAllUser(UserDetailsImpl userDetails) {
+       /*
         if (!userDetails.getUser().getRole().equals(UserRoleEnum.MASTER)) {
             throw new UserUnauthorizedException();
         }
-
+        */
         Sort.Direction direction = Sort.Direction.ASC;
         Pageable pageable = PageRequest.of(0, 10, Sort.by(direction, "nickname"));
 
@@ -103,7 +86,7 @@ public class UserService {
 
         return userPage.map(AdminUserRequestDto::of);
     }
-    
+
     public User getUserOrElseThrow(Long userId) {
         return userRepository.findById(userId)
             .orElseThrow(UserNotFoundException::new);

--- a/src/main/java/friends/aidelivery/user/presentation/UserController.java
+++ b/src/main/java/friends/aidelivery/user/presentation/UserController.java
@@ -32,15 +32,6 @@ public class UserController {
             HttpStatus.CREATED);
     }
 
-    @PostMapping("/login")
-    public ResponseEntity<CommonResponse> login(
-        @RequestBody final UserLoginRequestDto userLoginRequest) {
-
-        UserResponseDto response = userService.login(userLoginRequest);
-        log.info("리스폰스 이메일 : {}", response.email());
-        return new ResponseEntity<>(ResponseVOUtils.getSuccessResponse(response), HttpStatus.OK);
-    }
-
     @PostMapping("/logout")
     public ResponseEntity<CommonResponse> logout(
         @AuthenticationPrincipal UserDetailsImpl userDetails) {


### PR DESCRIPTION
## 📄 설명
<img width="1355" alt="스크린샷 2025-02-20 오후 11 02 49" src="https://github.com/user-attachments/assets/ed62bb62-b23e-4a02-9b8f-679ce6e9e309" />

> 인가 필터에서 DB 조회 로직을 삭제하고 userid가 token에 추가될 수 있게 해서, 
UserDetails에 유저 이메일, 권한, 유저 PK를 반환할 수 있게끔 했습니다.
> 사용하지 않는 유저 API 삭제했습니다.
> 클라이언트 쿠키 발급 부분에 Bearer 붙여서 발급받을 수 있게끔 했습니다.
> 필터 인증/인가 부분 테스트 전부 마쳤고, 유저 디테일스에 유저 정보가 담기는 것도 확인했습니다.

## 📌 관련 이슈

> #57

## ⚠️ 주의사항

> 머지 마치면 OrderController에서 오류가 나서 실행이 안 됩니다. 이 점만 주의해 주세요..!
