### PR TITLE
[Feat] 어드민 상태 변경 api 추가 및 조회 api 수정

### DIFF
--- a/src/main/java/friends/aidelivery/admin/application/AdminService.java
+++ b/src/main/java/friends/aidelivery/admin/application/AdminService.java
@@ -4,10 +4,13 @@ import friends.aidelivery.admin.application.dto.request.AdminUserStatusRequestDt
 import friends.aidelivery.admin.application.dto.request.AdminUserUpdateRequest;
 import friends.aidelivery.admin.application.dto.response.AdminUserRequestDto;
 import friends.aidelivery.admin.application.dto.response.AdminUserUpdateResponse;
+import friends.aidelivery.common.infrastructure.security.UserDetailsImpl;
 import friends.aidelivery.user.application.UserService;
 import friends.aidelivery.user.application.dto.response.UserResponseDto;
 import friends.aidelivery.user.domain.User;
+import friends.aidelivery.user.domain.enums.UserRoleEnum;
 import friends.aidelivery.user.domain.repository.UserRepository;
+import friends.aidelivery.user.exception.UserUnauthorizedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -22,13 +25,13 @@ public class AdminService {
 
     private final UserRepository userRepository;
     private final UserService userService;
-    
+
     public Page<AdminUserRequestDto> getUserList(int page, int size, String sortBy, boolean isAsc) {
 
         Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
         Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortBy));
 
-        Page<User> userPage = userRepository.findAll(pageable);
+        Page<User> userPage = userRepository.findAllByIsDeletedFalse(pageable);
 
         return userPage.map(AdminUserRequestDto::of);
     }
@@ -53,8 +56,14 @@ public class AdminService {
     }
 
     @Transactional
-    public AdminUserUpdateResponse updateUserStatus(Long userId,
+    public AdminUserUpdateResponse updateUserStatus(UserDetailsImpl userDetails, Long userId,
         AdminUserStatusRequestDto requestDto) {
+
+        // MANAGER 권한은 MASTER로 변경 불가
+        if (userDetails.getRole().equals(UserRoleEnum.MANAGER) && requestDto.role()
+            .equals(UserRoleEnum.MASTER)) {
+            throw new UserUnauthorizedException();
+        }
 
         User user = userService.getUserOrElseThrow(userId);
 

--- a/src/main/java/friends/aidelivery/admin/presentation/AdminController.java
+++ b/src/main/java/friends/aidelivery/admin/presentation/AdminController.java
@@ -6,6 +6,7 @@ import friends.aidelivery.admin.application.dto.request.AdminUserUpdateRequest;
 import friends.aidelivery.admin.application.dto.response.AdminUserRequestDto;
 import friends.aidelivery.admin.application.dto.response.AdminUserUpdateResponse;
 import friends.aidelivery.common.application.dto.CommonResponse;
+import friends.aidelivery.common.infrastructure.security.UserDetailsImpl;
 import friends.aidelivery.common.util.ResponseVOUtils;
 import friends.aidelivery.user.application.dto.response.UserResponseDto;
 import friends.aidelivery.user.domain.enums.UserRoleEnum.Authority;
@@ -14,7 +15,15 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/admins")
@@ -63,18 +72,10 @@ public class AdminController {
     @Secured({Authority.MANAGER, Authority.MASTER})
     @PutMapping("/{userId}/status")
     public ResponseEntity<CommonResponse> updateUserStatus(@PathVariable Long userId,
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
         @RequestBody AdminUserStatusRequestDto requestDto) {
-        AdminUserUpdateResponse response = adminService.updateUserStatus(userId, requestDto);
-
+        AdminUserUpdateResponse response = adminService.updateUserStatus(userDetails, userId,
+            requestDto);
         return new ResponseEntity<>(ResponseVOUtils.getSuccessResponse(response), HttpStatus.OK);
     }
-
-    /*
-    @Secured({"MANAGER", "MASTER"})
-    @PostMapping("/role")
-    public ResponseEntity<CommonResponse> updateUserRole(
-        @RequestBody AdminUserRoleEnumUpdateRequestDto requestDto) {
-
-    }
-     */
 }

--- a/src/main/java/friends/aidelivery/admin/presentation/AdminController.java
+++ b/src/main/java/friends/aidelivery/admin/presentation/AdminController.java
@@ -11,6 +11,7 @@ import friends.aidelivery.common.util.ResponseVOUtils;
 import friends.aidelivery.user.application.dto.response.UserResponseDto;
 import friends.aidelivery.user.domain.enums.UserRoleEnum.Authority;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequestMapping("/admins")
 @RequiredArgsConstructor
@@ -70,7 +72,7 @@ public class AdminController {
     }
 
     @Secured({Authority.MANAGER, Authority.MASTER})
-    @PutMapping("/{userId}/status")
+    @PutMapping("/status/{userId}")
     public ResponseEntity<CommonResponse> updateUserStatus(@PathVariable Long userId,
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @RequestBody AdminUserStatusRequestDto requestDto) {

--- a/src/main/java/friends/aidelivery/user/application/UserService.java
+++ b/src/main/java/friends/aidelivery/user/application/UserService.java
@@ -1,6 +1,5 @@
 package friends.aidelivery.user.application;
 
-import friends.aidelivery.admin.application.dto.response.AdminUserRequestDto;
 import friends.aidelivery.common.infrastructure.security.UserDetailsImpl;
 import friends.aidelivery.user.application.dto.request.UserDeleteRequestDto;
 import friends.aidelivery.user.application.dto.request.UserInfoRequestDto;
@@ -13,10 +12,6 @@ import friends.aidelivery.user.exception.UserNotFoundException;
 import friends.aidelivery.user.exception.UserPasswordMismatchException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -72,16 +67,6 @@ public class UserService {
     public UserResponseDto logout() {
 
         return null;
-    }
-
-    public Page<AdminUserRequestDto> findAllUser() {
-
-        Sort.Direction direction = Sort.Direction.ASC;
-        Pageable pageable = PageRequest.of(0, 10, Sort.by(direction, "nickname"));
-
-        Page<User> userPage = userRepository.findAll(pageable);
-
-        return userPage.map(AdminUserRequestDto::of);
     }
 
     public User getUserOrElseThrow(Long userId) {

--- a/src/main/java/friends/aidelivery/user/domain/User.java
+++ b/src/main/java/friends/aidelivery/user/domain/User.java
@@ -1,6 +1,7 @@
 package friends.aidelivery.user.domain;
 
 import friends.aidelivery.admin.application.dto.request.AdminUserUpdateRequest;
+import friends.aidelivery.common.domain.TimeStamp;
 import friends.aidelivery.user.application.dto.request.UserInfoRequestDto;
 import friends.aidelivery.user.domain.enums.UserRoleEnum;
 import friends.aidelivery.user.domain.vo.Address;
@@ -18,7 +19,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -30,7 +30,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @Table(name = "p_user")
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User implements Serializable {
+public class User extends TimeStamp {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/friends/aidelivery/user/domain/repository/UserRepository.java
+++ b/src/main/java/friends/aidelivery/user/domain/repository/UserRepository.java
@@ -14,6 +14,6 @@ public interface UserRepository {
     Optional<User> findByEmail(Email email);
 
     Optional<User> findById(Long id);
-
+    
     Page<User> findAllByIsDeletedFalse(Pageable pageable);
 }

--- a/src/main/java/friends/aidelivery/user/domain/repository/UserRepository.java
+++ b/src/main/java/friends/aidelivery/user/domain/repository/UserRepository.java
@@ -15,5 +15,5 @@ public interface UserRepository {
 
     Optional<User> findById(Long id);
 
-    Page<User> findAll(Pageable pageable);
+    Page<User> findAllByIsDeletedFalse(Pageable pageable);
 }

--- a/src/main/java/friends/aidelivery/user/infrastructure/UserRepositoryImpl.java
+++ b/src/main/java/friends/aidelivery/user/infrastructure/UserRepositoryImpl.java
@@ -50,7 +50,7 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
-    public Page<User> findAll(Pageable pageable) {
-        return jpaRepository.findAll(pageable);
+    public Page<User> findAllByIsDeletedFalse(Pageable pageable) {
+        return jpaRepository.findAllByIsDeletedFalse(pageable);
     }
 }

--- a/src/main/java/friends/aidelivery/user/infrastructure/jpa/UserJpaRepository.java
+++ b/src/main/java/friends/aidelivery/user/infrastructure/jpa/UserJpaRepository.java
@@ -17,4 +17,6 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
     Optional<User> findById(Long id);
 
     Page<User> findAll(Pageable pageable);
+
+    Page<User> findAllByIsDeletedFalse(Pageable pageable);
 }


### PR DESCRIPTION
## 📄 설명

> 어드민 권한 설정 해 줄 수 있는 API 추가했습니다. (포스트맨 테스트 완료)
> 어드민 유저 조회 리스트에 isDeleted false 조건 추가했습니다. (포스트맨 테스트 완료)

## 📌 관련 이슈

> #62

## ⚠️ 주의사항

> 기존 API 명세서와 다르게 권한 설정을 두 개로 나누지 않고 하나의 메서드로 기능을 합쳤습니다. 
> (권한에 따라 바꿀 수 있는 유저 스테이터스가 달라서 엔드포인트도 다르게 설정했는데, 이걸 하나의 메서드로 구현)
> API 명세서도 수정했습니다.
