### PR TITLE
[Feat] update user 수정 및 exception 수정

### DIFF
--- a/src/main/java/friends/aidelivery/common/presentation/GlobalExceptionHandler.java
+++ b/src/main/java/friends/aidelivery/common/presentation/GlobalExceptionHandler.java
@@ -6,9 +6,13 @@ import friends.aidelivery.common.exception.CustomForbiddenException;
 import friends.aidelivery.common.exception.CustomNotFoundException;
 import friends.aidelivery.common.exception.CustomUnauthorizedException;
 import friends.aidelivery.common.exception.code.CommonResultCode;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -59,5 +63,30 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(new CommonResponse(CommonResultCode.ERROR.code(),
                 CommonResultCode.ERROR.message()));
+    }
+
+    @ExceptionHandler(value = {AccessDeniedException.class})
+    public ResponseEntity<CommonResponse> handleAccessDeniedException(
+        final AccessDeniedException e) {
+        return ResponseEntity
+            .status(HttpStatus.FORBIDDEN)
+            .body(new CommonResponse(CommonResultCode.FORBIDDEN.code(),
+                CommonResultCode.FORBIDDEN.message()));
+    }
+
+    @ExceptionHandler(value = {MethodArgumentNotValidException.class})
+    public ResponseEntity<CommonResponse> handleMethodArgumentNotValidException(
+        final MethodArgumentNotValidException e) {
+
+        List<String> errorMessages = e.getBindingResult()
+            .getFieldErrors()
+            .stream()
+            .map(DefaultMessageSourceResolvable::getDefaultMessage) // 오류 메시지만 추출
+            .toList();
+
+        String message = errorMessages.isEmpty() ? "입력값 검증 실패" : errorMessages.get(0);
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(new CommonResponse(CommonResultCode.BAD_REQUEST.code(), message));
     }
 }

--- a/src/main/java/friends/aidelivery/user/application/UserService.java
+++ b/src/main/java/friends/aidelivery/user/application/UserService.java
@@ -48,7 +48,7 @@ public class UserService {
         User user = getUserOrElseThrow(userId);
 
         userMismatch(userDetails, userId);
-        user.updateUser(userInfoRequestDto);
+        user.updateUser(userInfoRequestDto, passwordEncoder);
         return UserResponseDto.of(user);
     }
 

--- a/src/main/java/friends/aidelivery/user/application/UserService.java
+++ b/src/main/java/friends/aidelivery/user/application/UserService.java
@@ -7,11 +7,15 @@ import friends.aidelivery.user.application.dto.response.UserInfoResponseDto;
 import friends.aidelivery.user.application.dto.response.UserResponseDto;
 import friends.aidelivery.user.domain.User;
 import friends.aidelivery.user.domain.repository.UserRepository;
+import friends.aidelivery.user.exception.UserDuplicateEmailException;
+import friends.aidelivery.user.exception.UserDuplicatePhoneException;
 import friends.aidelivery.user.exception.UserMismatchException;
 import friends.aidelivery.user.exception.UserNotFoundException;
 import friends.aidelivery.user.exception.UserPasswordMismatchException;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,9 +31,14 @@ public class UserService {
 
     @Transactional
     public UserInfoResponseDto singIn(UserInfoRequestDto userInfoRequestDto) {
-        User user = User.createUser(userInfoRequestDto, passwordEncoder);
-        User saved = userRepository.save(user);
-        return UserInfoResponseDto.of(saved);
+        try {
+            User user = User.createUser(userInfoRequestDto, passwordEncoder);
+            User saved = userRepository.save(user);
+            return UserInfoResponseDto.of(saved);
+        } catch (DataIntegrityViolationException e) {
+            handleDuplicateKeyException(e);
+        }
+        return null;
     }
 
     public UserResponseDto findUserInfo(Long userId, UserDetailsImpl userDetails) {
@@ -77,6 +86,15 @@ public class UserService {
     private void userMismatch(UserDetailsImpl userDetails, Long userId) {
         if (!userDetails.getUserId().equals(userId)) {
             throw new UserMismatchException();
+        }
+    }
+
+    private void handleDuplicateKeyException(DataIntegrityViolationException e) {
+        String message = Objects.requireNonNull(e.getRootCause()).getMessage(); // DB 에러 메시지 추출
+        if (message.contains("email")) {
+            throw new UserDuplicateEmailException();
+        } else if (message.contains("phone")) {
+            throw new UserDuplicatePhoneException();
         }
     }
 }

--- a/src/main/java/friends/aidelivery/user/application/dto/request/UserDeleteRequestDto.java
+++ b/src/main/java/friends/aidelivery/user/application/dto/request/UserDeleteRequestDto.java
@@ -1,9 +1,11 @@
 package friends.aidelivery.user.application.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class UserDeleteRequestDto {
 
+    @NotBlank(message = "암호를 입력해 주세요.")
     private String password;
 }

--- a/src/main/java/friends/aidelivery/user/domain/User.java
+++ b/src/main/java/friends/aidelivery/user/domain/User.java
@@ -74,12 +74,12 @@ public class User extends TimeStamp {
         this.isDeleted = false;
     }
 
-    public void updateUser(UserInfoRequestDto userInfoRequestDto) {
+    public void updateUser(UserInfoRequestDto userInfoRequestDto, PasswordEncoder passwordEncoder) {
         this.name = new Name(userInfoRequestDto.name());
         this.email = new Email(userInfoRequestDto.email());
         this.nickname = new Nickname(userInfoRequestDto.nickname());
         this.role = userInfoRequestDto.role();
-        this.password = userInfoRequestDto.password();
+        this.password = Password.encrypt(userInfoRequestDto.password(), passwordEncoder).getValue();
         this.address = new Address(userInfoRequestDto.address());
         this.phone = new Phone(userInfoRequestDto.phone());
     }

--- a/src/main/java/friends/aidelivery/user/exception/UserDuplicateEmailException.java
+++ b/src/main/java/friends/aidelivery/user/exception/UserDuplicateEmailException.java
@@ -1,0 +1,10 @@
+package friends.aidelivery.user.exception;
+
+import friends.aidelivery.common.exception.CustomBadRequestException;
+
+public class UserDuplicateEmailException extends CustomBadRequestException {
+
+    public UserDuplicateEmailException() {
+        super(521, "중복된 이메일입니다.");
+    }
+}

--- a/src/main/java/friends/aidelivery/user/exception/UserDuplicatePhoneException.java
+++ b/src/main/java/friends/aidelivery/user/exception/UserDuplicatePhoneException.java
@@ -1,0 +1,10 @@
+package friends.aidelivery.user.exception;
+
+import friends.aidelivery.common.exception.CustomBadRequestException;
+
+public class UserDuplicatePhoneException extends CustomBadRequestException {
+
+    public UserDuplicatePhoneException() {
+        super(520, "중복된 휴대전화 번호입니다.");
+    }
+}

--- a/src/main/java/friends/aidelivery/user/presentation/UserController.java
+++ b/src/main/java/friends/aidelivery/user/presentation/UserController.java
@@ -9,6 +9,7 @@ import friends.aidelivery.user.application.dto.request.UserInfoRequestDto;
 import friends.aidelivery.user.application.dto.response.UserInfoResponseDto;
 import friends.aidelivery.user.application.dto.response.UserResponseDto;
 import friends.aidelivery.user.domain.enums.UserRoleEnum.Authority;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +36,7 @@ public class UserController {
 
     @PostMapping("/signIn")
     public ResponseEntity<CommonResponse> signIn(
-        @RequestBody final UserInfoRequestDto userInfoRequestDto) {
+        @RequestBody @Valid final UserInfoRequestDto userInfoRequestDto) {
         UserInfoResponseDto response = userService.singIn(userInfoRequestDto);
         return new ResponseEntity<>(ResponseVOUtils.getSuccessResponse(response),
             HttpStatus.CREATED);
@@ -51,7 +52,7 @@ public class UserController {
     @PutMapping("/{userId}")
     public ResponseEntity<CommonResponse> updateUser(
         @AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long userId,
-        @RequestBody UserInfoRequestDto requestDto) {
+        @RequestBody @Valid UserInfoRequestDto requestDto) {
         UserResponseDto response = userService.updateUserInfo(userDetails, userId, requestDto);
 
         return new ResponseEntity<>(ResponseVOUtils.getSuccessResponse(response), HttpStatus.OK);
@@ -60,7 +61,7 @@ public class UserController {
     @DeleteMapping("/{userId}")
     public ResponseEntity<CommonResponse> deleteUser(@PathVariable Long userId,
         @AuthenticationPrincipal UserDetailsImpl userDetails,
-        @RequestBody UserDeleteRequestDto requestDto) {
+        @RequestBody @Valid UserDeleteRequestDto requestDto) {
         UserResponseDto response = userService.deleteUser(userDetails, userId, requestDto);
 
         return new ResponseEntity<>(ResponseVOUtils.getSuccessResponse(response), HttpStatus.OK);


### PR DESCRIPTION
## 📄 설명

> 유저 업데이트 API 패스워드 암호화 오류 수정했습니다. 
> 스프링 필터 인가 권한 체크에서 권한 익셉션이 터졌을 경우 커스텀 메시지를 반환할 수 있게 수정했습니다.
> IO에서 스프링이 제공하는 validation 어노테이션에 익셉션이 터졌을 경우 커스텀 메시지를 반환할 수 있게 수정했습니다.

## 📌 관련 이슈

> #65 

## ⚠️ 주의사항

> 권한 익셉션과 밸리데이션 익셉션의 코드는 글로벌 익셉션 핸들러로 고정해 두었습니다. 
> 권한 익셉션의 메시지도 고정해 두었습니다.
> 밸리데이션 익셉션 메시지는 커스텀 가능합니다. (예시: @NotBlank(message = "이름은 필수 입력 조건입니다.")
